### PR TITLE
🐛 redisにユーザIDとメールアドレスを保存するように修正

### DIFF
--- a/api/oauth_google.go
+++ b/api/oauth_google.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -132,7 +132,7 @@ func getUserDataFromGoogle(code string) ([]byte, error) {
 		return nil, fmt.Errorf("failed getting user info: %s", err.Error())
 	}
 	defer response.Body.Close()
-	contents, err := ioutil.ReadAll(response.Body)
+	contents, err := io.ReadAll(response.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed read response: %s", err.Error())
 	}


### PR DESCRIPTION
Closes #54

## 動作確認
- 新規ユーザ登録後、redis に ユーザIDとメールアドレスが保存されているか
- 新規ユーザ登録済みで、Googleログインした後、redis に ユーザIDとメールアドレスが保存されているか